### PR TITLE
Added blocklist functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@
 ## Blocklist
 
 - If the `--blocklist` flag is passed, `gb-dl` will lookup a `gb-dl-blocklist.json` in the current working directory. 
-- Before downloading a video it'll check if the video_show title is included in the blocklist and ignore the download is found.
+- Before downloading a video it'll check if the `video_show` title is included in the blocklist and ignore the download if found.
 - See [Examples](./examples) for an example blocklist.
 
 ## [More Examples](./examples)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 | --add-date-prefix      |        | false    | Prefixes the downloaded video with its publish date (e.g. "2021-05-08 - Quick Look\_ Forager.mp4")    |
 | --info                 |        | false    | Output video information instead of download.                                                         |
 | --archive              |        | false    | Check archive before downloading.                                                                     |
+| --blocklist            |        | false    | Check blocklist before downloading.                                                                   |
 | --clean                |        | false    | Ignore cache when making query.                                                                       |
 | --debug                |        | false    | Show debug statements.                                                                                |
 | --version              |        | false    | Output the version number.                                                                            |
@@ -71,5 +72,11 @@
 
 - If passed the `--archive` flag, `gb-dl` will generate/use a `gb-dl-archive.json` in the current working directory.
 - Before downloading a video, it'll check if the video was downloaded previously and abort the download if found.
+
+## Blocklist
+
+- If the `--blocklist` flag is passed, `gb-dl` will lookup a `gb-dl-blocklist.json` in the current working directory. 
+- Before downloading a video it'll check if the video_show title is included in the blocklist and ignore the download is found.
+- See [Examples](./examples) for an example blocklist.
 
 ## [More Examples](./examples)

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -64,6 +64,7 @@ program
   .option("--archive", "check if video exists in archive before downloading")
   .option("--clean", "ignore previous cache results for query")
   .option("--debug", "show debug statements")
+  .option("--blocklist", "check if show is on blocklist before downloading")
   .parse(process.argv);
 
 if (!program.apiKey && !GIANTBOMB_TOKEN) {
@@ -192,6 +193,7 @@ let main = async () => {
     outDir: program.outDir,
     quality: program.quality,
     archive: program.archive,
+    blocklist: program.blocklist,
     debug: program.debug,
     addGuidPrefix: program.addGuidPrefix,
     addDatePrefix: program.addDatePrefix,

--- a/bin/util.js
+++ b/bin/util.js
@@ -391,7 +391,7 @@ let downloadVideo = async ({
   }
 
   let downloadUrl = `${qualityUrl}?api_key=${apiKey}`;
-  let showTitle = video.video_show.title;
+  let showTitle = video.video_show && video.video_show.title ? video.video_show.title : null;
 
   /*
     The Giant Bomb API isn't returning the highest bitrate version

--- a/bin/util.js
+++ b/bin/util.js
@@ -424,7 +424,7 @@ let downloadVideo = async ({
     return;
   }
 
-  if (blocklist && isInBlocklist(showTitle)) {
+  if (blocklist && showTitle && isInBlocklist(showTitle)) {
     console.log(`show "${showTitle}" exists in blocklist`);
     console.log("ignoring...");
     return;

--- a/bin/util.js
+++ b/bin/util.js
@@ -51,6 +51,7 @@ let videosFieldList = [
   "high_url",
   "low_url",
   "premium",
+  "video_show"
 ];
 
 let searchFieldList = [...videosFieldList, "video_show"];
@@ -374,6 +375,7 @@ let downloadVideo = async ({
   outDir,
   debug,
   archive,
+  blocklist,
   addGuidPrefix,
   addDatePrefix,
 }) => {
@@ -389,6 +391,7 @@ let downloadVideo = async ({
   }
 
   let downloadUrl = `${qualityUrl}?api_key=${apiKey}`;
+  let showTitle = video.video_show.title;
 
   /*
     The Giant Bomb API isn't returning the highest bitrate version
@@ -421,6 +424,12 @@ let downloadVideo = async ({
     return;
   }
 
+  if (blocklist && isInBlocklist(showTitle)) {
+    console.log(`show "${showTitle}" exists in blocklist`);
+    console.log("ignoring...");
+    return;
+  }  
+  
   let safeFilename = filenamify(video.name, { replacement: "_" });
   let fileExt = path.extname(qualityUrl);
   let fullFilename =
@@ -592,6 +601,17 @@ let isInArchive = (downloadUrl) => {
   let archive = JSON.parse(fs.readFileSync(archivePath));
 
   return archive.includes(downloadUrl);
+};
+
+let blocklistPath = path.resolve(process.cwd(), "gb-dl-blocklist.json");
+let isInBlocklist = (showTitle) => {
+  if (!fs.existsSync(blocklistPath)) {
+    return false;
+  }
+
+  let blocklist = JSON.parse(fs.readFileSync(blocklistPath));
+
+  return blocklist.includes(showTitle);
 };
 
 module.exports = {

--- a/examples/gb-dl-blocklist.json
+++ b/examples/gb-dl-blocklist.json
@@ -1,0 +1,5 @@
+[
+    "ALBUMMER!",
+    "Quick Looks",
+    "Giant Bombcast"
+]


### PR DESCRIPTION
I've added the ability to use a blocklist. If `--blocklist` is defined in the arguments then a video download will be skipped if the show title exists in the blocklist. 

The use case for this is for someone that has the downloader set up to grab all recent videos, regardless of show. With this you can exclude specific shows from being downloaded. 

I've essentially duplicated the strucure of the archive function to create this. The blocklist follows the same json structure as the archive json too.